### PR TITLE
log-engine Update to 0.7.3 - case in/sensitive searches

### DIFF
--- a/log-engine/resources/config.json
+++ b/log-engine/resources/config.json
@@ -1,6 +1,6 @@
 {
   "core": {
-    "version": "0.7.2",
+    "version": "0.7.3",
     "logPath": "logs"
   },
   "adapters": {


### PR DESCRIPTION
* insensitive search is now default, can be changed by "caseSensitivity":true in the TextSearchPayload